### PR TITLE
Docs should specify tlslite version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ XMBC plugin.
   * Python 2.6+
   * requests
   * PyCrypto
+  * tlslite version 0.4.3 (`pip install tlslite===0.4.3`)
 
 ### Usage
 


### PR DESCRIPTION
Hi! This is a great tool but it was throwing errors on subtitle decryption until I figured out it needed a much older version of tlslite. This PR specifies which version is needed as a prerequisite.