### PR TITLE
fix StreamInfo model's "resolution" property

### DIFF
--- a/crunchyroll/models.py
+++ b/crunchyroll/models.py
@@ -185,9 +185,9 @@ class StreamInfo(XmlModel):
     @property
     def resolution(self):
         width = self.findfirst(
-            '//metadata/width').text
+            './/metadata/width').text
         height = self.findfirst(
-            '//metadata/height').text
+            './/metadata/height').text
         return (int(width), int(height))
 
 class MediaStream(XmlModel):


### PR DESCRIPTION
as published, calling `resolution` property of a StreamInfo element will always throw

```
SyntaxError: cannot use absolute path on element
```
