### PR TITLE
Python 3 Compatability

### DIFF
--- a/crunchyroll/apis/android.py
+++ b/crunchyroll/apis/android.py
@@ -25,6 +25,7 @@ import requests
 from crunchyroll.apis import ApiInterface
 from crunchyroll.constants import ANDROID
 from crunchyroll.apis.errors import *
+from crunchyroll.util import iteritems
 
 logger = logging.getLogger('crunchyroll.apis.android')
 
@@ -112,7 +113,7 @@ class AndroidApi(ApiInterface):
             'version':      ANDROID.APP_CODE,
         }
         base_params.update(dict((k, v) \
-            for k, v in self._state_params.iteritems() \
+            for k, v in iteritems(self._state_params) \
                 if v is not None))
         return base_params
 

--- a/crunchyroll/apis/android_manga.py
+++ b/crunchyroll/apis/android_manga.py
@@ -25,6 +25,7 @@ import requests
 from crunchyroll.apis import ApiInterface
 from crunchyroll.constants import ANDROID_MANGA
 from crunchyroll.apis.errors import *
+from crunchyroll.util import iteritems
 
 logger = logging.getLogger('crunchyroll.apis.android_manga')
 
@@ -85,7 +86,7 @@ class AndroidMangaApi(ApiInterface):
         }
 
         base_params.update(dict((k, v) \
-            for k, v in self._state_params.iteritems() \
+            for k, v in iteritems(self._state_params) \
                 if v is not None))
 
         return base_params

--- a/crunchyroll/apis/scraper.py
+++ b/crunchyroll/apis/scraper.py
@@ -22,6 +22,7 @@ import json
 from crunchyroll.apis import ApiInterface
 from crunchyroll.constants import SCRAPER
 from crunchyroll.apis.errors import *
+from crunchyroll.util import iteritems
 
 class ScraperApi(ApiInterface):
     """Website scraper API
@@ -39,7 +40,7 @@ class ScraperApi(ApiInterface):
         format_pattern = re.compile(SCRAPER.VIDEO.FORMAT_PATTERN)
         formats = {}
 
-        for format, param in SCRAPER.VIDEO.FORMAT_PARAMS.iteritems():
+        for format, param in iteritems(SCRAPER.VIDEO.FORMAT_PARAMS):
             resp = self._connector.get(url, params={param: '1'})
             if not resp.ok:
                 continue

--- a/crunchyroll/apis/scraper.py
+++ b/crunchyroll/apis/scraper.py
@@ -44,7 +44,10 @@ class ScraperApi(ApiInterface):
             resp = self._connector.get(url, params={param: '1'})
             if not resp.ok:
                 continue
-            match = format_pattern.search(resp.content)
+            try:
+                match = format_pattern.search(resp.content)
+            except TypeError:
+                match = format_pattern.search(resp.text)
             if match:
                 formats[format] = (int(match.group(1)), int(match.group(2)))
         return formats

--- a/crunchyroll/models.py
+++ b/crunchyroll/models.py
@@ -50,7 +50,11 @@ class DictModel(object):
 
 class XmlModel(object):
     def __init__(self, node):
-        if isinstance(node, basestring):
+        try:
+            is_basestring = isinstance(node, basestring)
+        except NameError:
+            is_basestring = isinstance(node, (bytes, str))
+        if is_basestring:
             try:
                 node = parse_xml_string(node)
             except Exception as err:

--- a/crunchyroll/models.py
+++ b/crunchyroll/models.py
@@ -86,7 +86,7 @@ class XmlModel(object):
     __unicode__ = __str__
 
     def __getitem__(self, name):
-        return map(XmlModel, self.findall('./' + name))
+        return list(map(XmlModel, self.findall('./' + name)))
 
     @property
     def text(self):
@@ -97,7 +97,7 @@ class XmlModel(object):
         return self._data.tag
 
     def findall(self, query):
-        return map(XmlModel, self._data.findall(query))
+        return list(map(XmlModel, self._data.findall(query)))
 
     def findfirst(self, query):
         try:

--- a/crunchyroll/subtitles.py
+++ b/crunchyroll/subtitles.py
@@ -23,6 +23,7 @@ import re
 import logging
 
 from tlslite.utils.cipherfactory import createAES
+from crunchyroll.util import iteritems
 
 logger = logging.getLogger('crunchyroll.subtitles')
 
@@ -203,7 +204,7 @@ Created: {created}
 
     def _format_style(self, style_element):
         attrs = style_element._data.attrib.copy()
-        for (k, v) in attrs.iteritems():
+        for (k, v) in iteritems(attrs):
             # wikipedia suggests that v4 uses b10, while v4+ uses b16
             if v.startswith('&H'):
                 attrs[k] = int(v[2:], 16)

--- a/crunchyroll/subtitles.py
+++ b/crunchyroll/subtitles.py
@@ -122,9 +122,9 @@ class SubtitleDecrypter(object):
         fbn_seq = list(seq_seed)
         for i in range(seq_len):
             fbn_seq.append(fbn_seq[-1] + fbn_seq[-2])
-        hash_secret = map(
+        hash_secret = list(map(
             lambda c: chr(c % mod_value + self.HASH_SECRET_CHAR_OFFSET),
-            fbn_seq[2:])
+            fbn_seq[2:]))
         return ''.join(hash_secret)
 
 class SubtitleFormatter(object):

--- a/crunchyroll/util.py
+++ b/crunchyroll/util.py
@@ -51,7 +51,7 @@ def return_collection(collection_type):
         @functools.wraps(func)
         def inner_func(self, *pargs, **kwargs):
             result = func(self, *pargs, **kwargs)
-            return map(collection_type, result)
+            return list(map(collection_type, result))
         return inner_func
     return outer_func
 

--- a/crunchyroll/util.py
+++ b/crunchyroll/util.py
@@ -20,10 +20,19 @@ import logging
 import functools
 import pipes
 import xml.etree.ElementTree as ET
+
 try:
     from HTMLParser import HTMLParser
 except ImportError:
     from html.parser import HTMLParser
+
+### Support itemitems() calls across versions
+try:
+    from six import iteritems
+except ImportError:
+    # from six: https://pythonhosted.org/six/
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
 
 from crunchyroll.constants import ANDROID_MANGA
 


### PR DESCRIPTION
- Version-agnostic `iteritems()`
- Account for `resp.content` returning as bytestream from `requests.Session().get()`
- Account for removal of `basestring` class
- Wrap `map`s in `list()` where appropriate